### PR TITLE
Report the case when there are extra attributes in the expected XML

### DIFF
--- a/Test-XML-Ordered/lib/Test/XML/Ordered.pm
+++ b/Test-XML-Ordered/lib/Test/XML/Ordered.pm
@@ -381,6 +381,14 @@ sub _get_diag_message
             . "Expected at "
             . $self->_expected->lineNumber();
     }
+    elsif ( $status_struct->{param} eq "extra_attr_expected" )
+    {
+        return
+              "Extra attribute for expected at "
+            . $self->_expected->lineNumber() . " ; "
+            . "Gotten at "
+            . $self->_got->lineNumber();
+    }
     elsif ( $status_struct->{param} eq "attr_localName" )
     {
         return

--- a/Test-XML-Ordered/lib/Test/XML/Ordered.pm
+++ b/Test-XML-Ordered/lib/Test/XML/Ordered.pm
@@ -384,10 +384,10 @@ sub _get_diag_message
     elsif ( $status_struct->{param} eq "extra_attr_expected" )
     {
         return
-              "Extra attribute for expected at "
-            . $self->_expected->lineNumber() . " ; "
-            . "Gotten at "
-            . $self->_got->lineNumber();
+              "Missing attribute for got at "
+            . $self->_got->lineNumber() . " ; "
+            . "Expected at "
+            . $self->_expected->lineNumber();
     }
     elsif ( $status_struct->{param} eq "attr_localName" )
     {

--- a/Test-XML-Ordered/t/attribute_compare_1.t
+++ b/Test-XML-Ordered/t/attribute_compare_1.t
@@ -19,16 +19,16 @@ is_xml_ordered(
 test_test("is_xml_ordered fails on extra attribute in 'have' XML.");
 
 # TEST
-test_out("not ok 1 - extra attribute for expected");
-test_diag("Extra attribute for expected at 1 ; Gotten at 1");
+test_out("not ok 1 - missing attribute for got");
+test_diag("Missing attribute for got at 1 ; Expected at 1");
 test_fail(+1);
 is_xml_ordered(
     [ string => '<xml/>' ],
     [ string => '<xml stuff="bar"/>' ],
     {},
-    'extra attribute for expected'
+    'missing attribute for got'
 );
-test_test("is_xml_ordered fails on extra attribute in 'expected' XML.");
+test_test("is_xml_ordered fails on missing attribute in 'have' XML.");
 
 # TEST
 test_out("not ok 1 - Attribute value mismatch");

--- a/Test-XML-Ordered/t/attribute_compare_1.t
+++ b/Test-XML-Ordered/t/attribute_compare_1.t
@@ -3,19 +3,32 @@
 use strict;
 use warnings;
 
-use Test::Builder::Tester tests => 2;
+use Test::Builder::Tester tests => 3;
 use Test::XML::Ordered qw(is_xml_ordered);
 
 # TEST
-test_out("not ok 1 - XML structure");
+test_out("not ok 1 - extra attribute for got");
 test_diag("Extra attribute for got at 1 ; Expected at 1");
 test_fail(+1);
 is_xml_ordered(
     [ string => '<xml stuff="foo"/>' ],
     [ string => '<xml/>' ],
-    {}, 'XML structure'
+    {},
+    'extra attribute for got'
 );
 test_test("is_xml_ordered fails on extra attribute in 'have' XML.");
+
+# TEST
+test_out("not ok 1 - extra attribute for expected");
+test_diag("Extra attribute for expected at 1 ; Gotten at 1");
+test_fail(+1);
+is_xml_ordered(
+    [ string => '<xml/>' ],
+    [ string => '<xml stuff="bar"/>' ],
+    {},
+    'extra attribute for expected'
+);
+test_test("is_xml_ordered fails on extra attribute in 'expected' XML.");
 
 # TEST
 test_out("not ok 1 - Attribute value mismatch");


### PR DESCRIPTION
This PR adds the diagnostic message for the case when there are extra attributes in the expected XML. This is reported as missing attributes in the gotten XML.